### PR TITLE
patch glibc to an older version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ RUN rm Dockerfile; \
     chmod +x scripts/1vyprep-get-roms.sh; \
     chmod +x scripts/build-iso.sh
 
+RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst && \
+curl -LO "https://repo.archlinuxcn.org/x86_64/$patched_glibc" && \
+bsdtar -C / -xvf "$patched_glibc"
+
 RUN pacman -Sy --noconfirm \
     wimlib \
     cdrkit \


### PR DESCRIPTION
Building the docker image resulted in the following error on pacman command

```
error: failed to initialize alpm library
(could not find or read directory: /var/lib/pacman/)
```

Found an [answer](https://stackoverflow.com/a/66163228) which fixes the
issue by patching glibc to an older version